### PR TITLE
fix: add missing click dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ certifi==2024.12.14
     # via requests
 charset-normalizer==3.4.0
     # via requests
+click==8.4.1
+    # via testbench2robotframework (pyproject.toml)
 check-manifest==0.50
     # via testbench2robotframework (pyproject.toml)
 colorama==0.4.6


### PR DESCRIPTION
## Problem

`click` is declared in `pyproject.toml` dependencies and used in `testbench2robotframework/cli.py`, but is missing from the pip-compile generated `requirements.txt`.

This causes `pip install -r requirements.txt` to fail with a missing `click` module error.

Fixes #15

## Fix

Add `click==8.4.1` to `requirements.txt` in alphabetical order (between `charset-normalizer` and `colorama`).
